### PR TITLE
Update snmpv3.py

### DIFF
--- a/syslog_monitoring/Snmp/snmpv3.py
+++ b/syslog_monitoring/Snmp/snmpv3.py
@@ -139,7 +139,7 @@ if __name__ == '__main__':
     message = ' '.join(string for string in sys.argv[4])
     err_type = sys.argv[5]
     host = sys.argv[6]
-    pool = Pool(processes=5)
+    pool = Pool(processes=1)
     sendTrapFunc = partial(send_trap, cond, level, keypair, message, err_type, host)
     basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
     with open(basedir + '/Config/snmp_config.json') as f:

--- a/syslog_monitoring/filters.conf
+++ b/syslog_monitoring/filters.conf
@@ -1,9 +1,9 @@
 # Copyright 2019 BlueCat Networks. All rights reserved.
 # Filter
 filter f_load_configuration_failure{
-	match("(re)*loading configuration.*(failed)*" value("MESSAGE"));
+	match("(re)*^loading configuration.*(failed)*" value("MESSAGE"));
 	and
-    not match("(re)*loading configuration.*success" value("MESSAGE"));
+    not match("(re)*^loading configuration.*success" value("MESSAGE"));
 };
 
 filter f_load_configuration_success{


### PR DESCRIPTION
change to use 1 process to resolve snmp issue with multiple server.

When run snmptrap command to send trap, snmptrap remove /var/lib/snmp/snmpapp.conf file and create new file with engineBoots value. If /var/lib/snmp/snmpapp.conf is not available, engineBoots value is 0. 

syslog-mon is configured to send trap to 3 servers and syslon-mon uses multiple processes for sending trap. When first trap is sent, snmptrap removes snmpapp.conf file to update engineBoots. At the same time, the second snmptrap process checks snmpapp.conf file and cannot find snmpapp.conf file so it will create new one with engineBoots  value is 0.