### PR TITLE
Release v2.1.2: Change to use CMD with syslog-ng instead of service 

### DIFF
--- a/services/docker.syslog.service
+++ b/services/docker.syslog.service
@@ -9,7 +9,7 @@ Environment=IMAGE_NAME='syslog_monitoring:<TAG_RELEASE>'               \
             NAME='syslog-sv'
 ExecStartPre=-/usr/bin/docker stop   $NAME      2> /dev/null || true
 ExecStartPre=-/usr/bin/docker rm     $NAME      2> /dev/null || true
-ExecStart=/usr/bin/docker run -d -it --restart unless-stopped       \
+ExecStart=/usr/bin/docker run --rm                                 \
                               --network=host                        \
                               --name $NAME                          \
                               -v  /var/log/syslog_monitoring/:/var/log/mon-app  \

--- a/syslog_monitoring/Dockerfile
+++ b/syslog_monitoring/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV PYTHONPATH /etc/syslog-ng/syslog_monitoring
+
 RUN apt-get update && \
     apt-get install -y gnupg2 syslog-ng-core syslog-ng python-pip snmp snmpd && \
     mv /etc/syslog-ng/syslog-ng.conf /etc/syslog-ng/syslog-ng-backup.conf
@@ -11,12 +13,11 @@ RUN mkdir /var/log/mon-app /var/log/mon-app/fw-log /var/log/mon-app/filter-log &
 COPY . /etc/syslog-ng/syslog_monitoring
 COPY filters.conf /usr/share/syslog-ng/include/scl/
 
-RUN echo 'export PYTHONPATH=/etc/syslog-ng/syslog_monitoring' >> /etc/default/syslog-ng && \
-    echo 'service syslog-ng start' >> /etc/bash.bashrc && \
+RUN \
     pip install wheel && \
     pip install -r /etc/syslog-ng/syslog_monitoring/requirements.txt && \
     apt-get install -y tzdata && \
     dpkg-reconfigure tzdata && \
     apt-get install ntp -y
 
-CMD ["/bin/bash"]
+CMD ["syslog-ng", "--process-mode=foreground"]


### PR DESCRIPTION
- Update Dockerfile change to use CMD with syslog-ng instead of service
- Update docker.service.syslog service file: remove --restart and -it, add --rm in docker run cmd